### PR TITLE
Wrap footer text on smaller screens

### DIFF
--- a/notes/static/notes/dark.css
+++ b/notes/static/notes/dark.css
@@ -127,7 +127,8 @@ a.article-title:hover {
   left: 0;
   bottom: 0;
   width: 100%;
-  height: 18px;
+  height: auto;
+  min-height: 18px;
   background: #1c1c1c;
   color: white;
   text-align: center;


### PR DESCRIPTION
Partially addresses #3.
Makes it so the footer text isn't just cut off from the end on mobile devices.