### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/todo/tests/test_models.py
+++ b/todo/tests/test_models.py
@@ -13,6 +13,6 @@ class TestModels(TestCase):
         task = baker.make(Todo, title="Sum2Prove")
         self.assertEqual(str(task), "Sum2Prove")
 
-    def test_event_model(self):
+    def test_event_model_two(self):
         task = baker.make(Todo, title="Sum2Prove")
         self.assertEqual(str(task), "Sum2Prove")

--- a/todo/tests/test_urls.py
+++ b/todo/tests/test_urls.py
@@ -18,14 +18,14 @@ class TestUrls(SimpleTestCase):
         url = reverse("todo:detail", args=["3"])
         self.assertEquals(resolve(url).func.view_class, TodoDetailView)
 
-    def test_list_url_is_resolves_two(self):
+    def test_list_url_is_resolves_three(self):
         url = reverse("todo:create")
         self.assertEquals(resolve(url).func.view_class, TodoCreateView)
 
-    def test_list_url_is_resolves_two(self):
+    def test_list_url_is_resolves_four(self):
         url = reverse("todo:delete", args=["3"])
         self.assertEquals(resolve(url).func.view_class, TodoDeleteView)
 
-    def test_list_url_is_resolves_two(self):
+    def test_list_url_is_resolves_five(self):
         url = reverse("todo:update", args=["3"])
         self.assertEquals(resolve(url).func.view_class, TodoUpdateView)

--- a/todo/tests/test_urls.py
+++ b/todo/tests/test_urls.py
@@ -14,18 +14,18 @@ class TestUrls(SimpleTestCase):
         url = reverse("todo:list")
         self.assertEquals(resolve(url).func.view_class, TodoListView)
 
-    def test_list_url_is_resolves(self):
+    def test_list_url_is_resolves_two(self):
         url = reverse("todo:detail", args=["3"])
         self.assertEquals(resolve(url).func.view_class, TodoDetailView)
 
-    def test_list_url_is_resolves(self):
+    def test_list_url_is_resolves_two(self):
         url = reverse("todo:create")
         self.assertEquals(resolve(url).func.view_class, TodoCreateView)
 
-    def test_list_url_is_resolves(self):
+    def test_list_url_is_resolves_two(self):
         url = reverse("todo:delete", args=["3"])
         self.assertEquals(resolve(url).func.view_class, TodoDeleteView)
 
-    def test_list_url_is_resolves(self):
+    def test_list_url_is_resolves_two(self):
         url = reverse("todo:update", args=["3"])
         self.assertEquals(resolve(url).func.view_class, TodoUpdateView)


### PR DESCRIPTION
Fixes #67.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

